### PR TITLE
Update EDuke32 to revision 8904

### DIFF
--- a/com.eduke32.EDuke32.appdata.xml
+++ b/com.eduke32.EDuke32.appdata.xml
@@ -24,7 +24,7 @@
 		</screenshot>
 	</screenshots>
 	<releases>
-		<release version="r7888" date="2019-08-04"/>
+		<release version="r8904" date="2020-05-05"/>
 	</releases>
 	<url type="homepage">https://www.eduke32.com/</url>
 	<url type="help">https://wiki.eduke32.com</url>

--- a/com.eduke32.EDuke32.yaml
+++ b/com.eduke32.EDuke32.yaml
@@ -40,8 +40,8 @@ modules:
       - install -d "${FLATPAK_DEST}/extensions"
     sources:
       - type: archive
-        url: http://dukeworld.duke4.net/eduke32/synthesis/20190804-7888/eduke32_src_20190804-7888.tar.xz
-        sha256: efd616405032d525d97b807ce2a835728561f0e29063099d59d7467904ab908b
+        url: http://dukeworld.duke4.net/eduke32/synthesis/20200505-8904-0b0e9923c/eduke32_src_20200505-8904-0b0e9923c.tar.xz
+        sha256: b92157eae9c8ff9f3dfbfebd136c66dee7e5e05cdc34851ca8dd2c69fd32d09f
       - type: patch
         path: flatpak_paths.patch
       - type: file


### PR DESCRIPTION
It builds fine locally but have not tried running it yet with the proprietary assets.

Might be worth adding support for the [external data checker](https://github.com/flathub/flatpak-external-data-checker) in the future, as upstream seems to be releasing revisions on a regular basis.