### PR TITLE
Add flatpaked steam to content search paths

### DIFF
--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -11,6 +11,10 @@ finish-args:
   - --device=all
   # For storing game files
   - --filesystem=xdg-documents/EDuke32:create
+  # For detecting existing game files
+  - --filesystem=~/.var/app/com.valvesoftware.Steam
+  - --filesystem=xdg-data/Steam
+  - --filesystem=~/.steam
   # Unfortunately doesn't seem to respect XDG
   - --persist=.config/eduke32
 add-extensions:

--- a/flatpak_paths.patch
+++ b/flatpak_paths.patch
@@ -1,18 +1,29 @@
 diff --git a/source/duke3d/src/common.cpp b/source/duke3d/src/common.cpp
-index db1dab4..d46a385 100644
---- a/source/duke3d/src/common.cpp	
+index db09fb5b4..006561b00 100644
+--- a/source/duke3d/src/common.cpp
 +++ b/source/duke3d/src/common.cpp
-@@ -789,6 +789,7 @@ void G_AddSearchPaths(void)
+@@ -597,10 +597,18 @@ void G_AddSearchPaths(void)
  #if defined __linux__ || defined EDUKE32_BSD
      char buf[BMAX_PATH];
      char *homepath = Bgethomedir();
 +    char *xdg_docs_path = getenv("XDG_DOCUMENTS_DIR");
  
      Bsnprintf(buf, sizeof(buf), "%s/.steam/steam", homepath);
-     G_AddSteamPaths(buf);
-@@ -796,12 +797,23 @@ void G_AddSearchPaths(void)
+     Duke_AddSteamPaths(buf);
+ 
++    // Steam Flatpak
++    Bsnprintf(buf, sizeof(buf), "%s/.var/app/com.valvesoftware.Steam/.steam/steam", homepath);
++    Duke_AddSteamPaths(buf);
++
++    Bsnprintf(buf, sizeof(buf), "%s/.var/app/com.valvesoftware.Steam/.steam/steam/steamapps/libraryfolders.vdf", homepath);
++    Paths_ParseSteamLibraryVDF(buf, Duke_AddSteamPaths);
++
      Bsnprintf(buf, sizeof(buf), "%s/.steam/steam/steamapps/libraryfolders.vdf", homepath);
-     G_ParseSteamKeyValuesForPaths(buf);
+     Paths_ParseSteamLibraryVDF(buf, Duke_AddSteamPaths);
+ 
+@@ -614,12 +622,23 @@ void G_AddSearchPaths(void)
+     Fury_Add_GOG_Linux(buf);
+     Paths_ParseXDGDesktopFilesFromGOG(homepath, "ION_Fury", Fury_Add_GOG_Linux);
  
 +    if (xdg_docs_path) {
 +        Bsnprintf(buf, sizeof(buf), "%s/Eduke32", xdg_docs_path);


### PR DESCRIPTION
Give the EDuke32 flatpak access to flatpaked Steam and update the search path patch to check flatpaked steam directories.