### PR TITLE
Content from Flatpaked Steam and Shadow Warrior Support

### DIFF
--- a/com.eduke32.EDuke32-mapster32.desktop
+++ b/com.eduke32.EDuke32-mapster32.desktop
@@ -4,4 +4,4 @@ Name=Mapster32
 Exec=mapster32
 Icon=com.eduke32.EDuke32-mapster32
 Categories=Game;Construction
-Keywords=Game;Shooter;Duke32;Duke;Nukem;3D;Map;Editor;
+Keywords=Game;Shooter;Build;Duke32;Duke;Nukem;3D;Map;Editor;

--- a/com.eduke32.EDuke32-voidsw.desktop
+++ b/com.eduke32.EDuke32-voidsw.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=VoidSW
+Exec=voidsw
+Icon=com.eduke32.EDuke32-voidsw
+Categories=Game;Shooter
+Keywords=Game;Shooter;Duke32;Build;Shadow;Warrior;SW

--- a/com.eduke32.EDuke32-wangulator.desktop
+++ b/com.eduke32.EDuke32-wangulator.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Wangulator
+Exec=wangulator
+Icon=com.eduke32.EDuke32-voidsw
+Categories=Game;Construction
+Keywords=Game;Shooter;Build;Duke32;Map;Editor;Shadow;Warrior;SW

--- a/com.eduke32.EDuke32.appdata.xml
+++ b/com.eduke32.EDuke32.appdata.xml
@@ -6,11 +6,29 @@
   <name>EDuke32</name>
   <summary>EDuke32 is an awesome, free homebrew game engine</summary>
   <description>
-    <p>EDuke32 is a free game engine and a source port of the classic PC first person shooter Duke Nukem 3D. It is free to use for non-commercial purposes, and contains many additional features useful to homebrew makers.</p>
-    <p>Compared to the original version, it also contains a lot of enhancements for players, such as a lot of bug fixes, support for real 3D OpenGL output, and high resolutions.</p>
-    <p>EDuke32 comes with a map editor, Mapster32, for creation of new levels.</p>
+    <p>
+      EDuke32 is a source port of Ken Silverman's Build Engine with support for
+      Duke Nukem 3D, Ion Fury and Shadow Warrior (via VoidSW), among others.
+    </p>
+    <p>
+      Features include:
+    </p>
+    <ul>
+      <li>Modern OpenGL rendering with dynamically lighting and shadows</li>
+      <li>Voxel assets</li>
+      <li>Emulated OPL3, MIDI or OGG/FLAC soundtracks</li>
+      <li>Gamepad support</li>
+      <li>Classic software rendering</li>
+    </ul>
+    <p>
+      EDuke32 comes with a map editors, Mapster32 and Wangulator, for creation
+      of new levels and is free to use for non-commercial purposes.
+    </p>
   </description>
   <launchable type="desktop-id">com.eduke32.EDuke32.desktop</launchable>
+  <launchable type="desktop-id">com.eduke32.EDuke32-mapster32.desktop</launchable>
+  <launchable type="desktop-id">com.eduke32.EDuke32-voidsw.desktop</launchable>
+  <launchable type="desktop-id">com.eduke32.EDuke32-wangulator.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://www.eduke32.com/images/shots/polymer2.jpg</image>

--- a/com.eduke32.EDuke32.desktop
+++ b/com.eduke32.EDuke32.desktop
@@ -4,4 +4,4 @@ Name=EDuke32
 Exec=eduke32
 Icon=com.eduke32.EDuke32
 Categories=Game;Shooter
-Keywords=Game;Shooter;Duke32;Duke;Nukem;3D;
+Keywords=Game;Shooter;Build;Duke32;Duke;Nukem;3D;

--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -11,6 +11,10 @@ finish-args:
   - --device=all
   # For storing game files
   - --filesystem=xdg-documents/EDuke32:create
+  # For detecting existing game files
+  - --filesystem=~/.var/app/com.valvesoftware.Steam
+  - --filesystem=xdg-data/Steam
+  - --filesystem=~/.steam
   # Unfortunately doesn't seem to respect XDG
   - --persist=.config/eduke32
 add-extensions:

--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -30,15 +30,19 @@ modules:
   - name: EDuke32
     buildsystem: simple
     build-commands:
-      - make -j${FLATPAK_BUILDER_N_JOBS}
-      - install -Dm755 -t ${FLATPAK_DEST}/bin/ eduke32 mapster32
-      - install -Dm644 -t ${FLATPAK_DEST}/share/applications/ com.eduke32.EDuke32.desktop
+      - make duke3d sw kenbuild -j${FLATPAK_BUILDER_N_JOBS}
+      - install -Dm755 -t ${FLATPAK_DEST}/bin/ eduke32 mapster32 voidsw wangulator ekenbuild ekenbuild-editor
+      - install -Dm644 -t ${FLATPAK_DEST}/share/applications/
+        com.eduke32.EDuke32.desktop
         com.eduke32.EDuke32-mapster32.desktop
+        com.eduke32.EDuke32-voidsw.desktop
+        com.eduke32.EDuke32-wangulator.desktop
       - install -Dm644 -t ${FLATPAK_DEST}/share/appdata/ com.eduke32.EDuke32.appdata.xml
       - install -Dm644 ${FLATPAK_ID}-64.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.png
       - install -Dm644 ${FLATPAK_ID}-mapster32-64.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}-mapster32.png
       - install -Dm644 ${FLATPAK_ID}-128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png
       - install -Dm644 ${FLATPAK_ID}-mapster32-128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}-mapster32.png
+      - install -Dm644 source/sw/rsrc/game_icon.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}-voidsw.svg
     post-install:
       - install -d "${FLATPAK_DEST}/extensions"
     sources:
@@ -58,6 +62,10 @@ modules:
         path: com.eduke32.EDuke32.desktop
       - type: file
         path: com.eduke32.EDuke32-mapster32.desktop
+      - type: file
+        path: com.eduke32.EDuke32-voidsw.desktop
+      - type: file
+        path: com.eduke32.EDuke32-wangulator.desktop
       - type: file
         path: icons/com.eduke32.EDuke32-64.png
       - type: file

--- a/flatpak_paths.patch
+++ b/flatpak_paths.patch
@@ -1,18 +1,29 @@
 diff --git a/source/duke3d/src/common.cpp b/source/duke3d/src/common.cpp
-index db1dab4..d46a385 100644
---- a/source/duke3d/src/common.cpp	
+index db09fb5b4..006561b00 100644
+--- a/source/duke3d/src/common.cpp
 +++ b/source/duke3d/src/common.cpp
-@@ -789,6 +789,7 @@ void G_AddSearchPaths(void)
+@@ -597,10 +597,18 @@ void G_AddSearchPaths(void)
  #if defined __linux__ || defined EDUKE32_BSD
      char buf[BMAX_PATH];
      char *homepath = Bgethomedir();
 +    char *xdg_docs_path = getenv("XDG_DOCUMENTS_DIR");
  
      Bsnprintf(buf, sizeof(buf), "%s/.steam/steam", homepath);
-     G_AddSteamPaths(buf);
-@@ -796,12 +797,23 @@ void G_AddSearchPaths(void)
+     Duke_AddSteamPaths(buf);
+ 
++    // Steam Flatpak
++    Bsnprintf(buf, sizeof(buf), "%s/.var/app/com.valvesoftware.Steam/.steam/steam", homepath);
++    Duke_AddSteamPaths(buf);
++
++    Bsnprintf(buf, sizeof(buf), "%s/.var/app/com.valvesoftware.Steam/.steam/steam/steamapps/libraryfolders.vdf", homepath);
++    Paths_ParseSteamLibraryVDF(buf, Duke_AddSteamPaths);
++
      Bsnprintf(buf, sizeof(buf), "%s/.steam/steam/steamapps/libraryfolders.vdf", homepath);
-     G_ParseSteamKeyValuesForPaths(buf);
+     Paths_ParseSteamLibraryVDF(buf, Duke_AddSteamPaths);
+ 
+@@ -614,12 +622,23 @@ void G_AddSearchPaths(void)
+     Fury_Add_GOG_Linux(buf);
+     Paths_ParseXDGDesktopFilesFromGOG(homepath, "ION_Fury", Fury_Add_GOG_Linux);
  
 +    if (xdg_docs_path) {
 +        Bsnprintf(buf, sizeof(buf), "%s/Eduke32", xdg_docs_path);

--- a/flatpak_paths.patch
+++ b/flatpak_paths.patch
@@ -45,3 +45,50 @@ index db09fb5b4..006561b00 100644
  #elif defined EDUKE32_OSX
      char buf[BMAX_PATH];
      int32_t i;
+diff --git a/source/sw/src/common.cpp b/source/sw/src/common.cpp
+index de123630e..db8131295 100644
+--- a/source/sw/src/common.cpp
++++ b/source/sw/src/common.cpp
+@@ -158,10 +158,18 @@ static void SW_AddSearchPaths()
+ #if defined __linux__ || defined EDUKE32_BSD
+     char buf[BMAX_PATH];
+     char *homepath = Bgethomedir();
++    char *xdg_docs_path = getenv("XDG_DOCUMENTS_DIR");
+ 
+     Bsnprintf(buf, sizeof(buf), "%s/.steam/steam", homepath);
+     SW_AddSteamPaths(buf);
+ 
++    // Steam Flatpak
++    Bsnprintf(buf, sizeof(buf), "%s/.var/app/com.valvesoftware.Steam/.steam/steam", homepath);
++    SW_AddSteamPaths(buf);
++
++    Bsnprintf(buf, sizeof(buf), "%s/.var/app/com.valvesoftware.Steam/.steam/steam/steamapps/libraryfolders.vdf", homepath);
++    Paths_ParseSteamLibraryVDF(buf, SW_AddSteamPaths);
++
+     Bsnprintf(buf, sizeof(buf), "%s/.steam/steam/steamapps/libraryfolders.vdf", homepath);
+     Paths_ParseSteamLibraryVDF(buf, SW_AddSteamPaths);
+ 
+@@ -175,12 +183,23 @@ static void SW_AddSearchPaths()
+     SW_Add_GOG_SWCC_Linux(buf);
+     Paths_ParseXDGDesktopFilesFromGOG(homepath, "Shadow_Warrior_Classic_Complete", SW_Add_GOG_SWCC_Linux);
+ 
++    if (xdg_docs_path) {
++        Bsnprintf(buf, sizeof(buf), "%s/VoidSW", xdg_docs_path);
++        addsearchpath(buf);
++    }
++    else {
++        Bsnprintf(buf, sizeof(buf), "%s/Documents/VoidSW", homepath);
++        addsearchpath(buf);
++    }
++
+     Xfree(homepath);
++    Xfree(xdg_docs_path);
+ 
+     addsearchpath("/usr/share/games/jfsw");
+     addsearchpath("/usr/local/share/games/jfsw");
+     addsearchpath("/usr/share/games/voidsw");
+     addsearchpath("/usr/local/share/games/voidsw");
++    addsearchpath("/app/extensions/extra");
+ #elif defined EDUKE32_OSX
+     char buf[BMAX_PATH];
+     int32_t i;


### PR DESCRIPTION
Give the EDuke32 flatpak access to flatpaked Steam and update the search path patch to check flatpaked steam directories.
Compile VoidSW to support the Build Engine game Shadow Warrior.