### PR TITLE
Use versioned tarball url and update to latest

### DIFF
--- a/com.eduke32.EDuke32.appdata.xml
+++ b/com.eduke32.EDuke32.appdata.xml
@@ -44,6 +44,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="20230609-10303-873de4072" date="2023-06-09"/>
     <release version="20230529-10285-726e72560" date="2023-05-29"/>
     <release version="20230314-10168-ef5f15e45" date="2023-03-15"/>
     <release version="20230123-10167-1a90b9883" date="2023-01-24"/>

--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -51,7 +51,7 @@ modules:
           type: html
           url: https://dukeworld.com/eduke32/synthesis/latest/
           version-pattern: eduke32_src_(\d{8}-\d+-[a-g0-9]+).tar.xz
-          url-template: https://dukeworld.com/eduke32/synthesis/latest/eduke32_src_$version.tar.xz
+          url-template: https://dukeworld.com/eduke32/synthesis/$version/eduke32_src_$version.tar.xz
       - type: patch
         path: flatpak_paths.patch
       - type: file

--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -45,8 +45,8 @@ modules:
       - install -d "${FLATPAK_DEST}/extensions"
     sources:
       - type: archive
-        url: https://dukeworld.com/eduke32/synthesis/latest/eduke32_src_20230529-10285-726e72560.tar.xz
-        sha256: 18d696286ed90fd0bb42da5431ff0fff16f7e54aee33fa8367b473e91502940f
+        url: https://dukeworld.com/eduke32/synthesis/20230609-10303-873de4072/eduke32_src_20230609-10303-873de4072.tar.xz
+        sha256: fc0816f949f0383a60aeb7e44460d92c804b754dfb746b2abf91a9e329490b0b
         x-checker-data:
           type: html
           url: https://dukeworld.com/eduke32/synthesis/latest/


### PR DESCRIPTION
Testing old versions by checking out commits doesn't work as the url points to the `latest` directory rather than the version number.