### PR TITLE
Add persistent directory for VoidSW configuration

### DIFF
--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -17,6 +17,7 @@ finish-args:
   - --filesystem=~/.steam
   # Unfortunately doesn't seem to respect XDG
   - --persist=.config/eduke32
+  - --persist=.config/voidsw
 add-extensions:
   com.eduke32.EDuke32.DukeNukem3DShareware:
     directory: extensions


### PR DESCRIPTION
This change should allow VoidSW to access its configuration directory in .config/voidsw

This is necessary for Shadow Warrior and its expansions to appear in the VoidSW launcher, and for VoidSW's settings to be saved properly. The issue can currently be fixed by the user by adding the directory in Flatseal or similar.