### PR TITLE
Add $XDG_DOCUMENTS_DIR/VoidSW

### DIFF
--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -11,6 +11,7 @@ finish-args:
   - --device=all
   # For storing game files
   - --filesystem=xdg-documents/EDuke32:create
+  - --filesystem=xdg-documents/VoidSW:create
   # For detecting existing game files
   - --filesystem=~/.var/app/com.valvesoftware.Steam
   - --filesystem=xdg-data/Steam


### PR DESCRIPTION
This change slipped thru the cracks after adding persistent `~/.config/voidsw` [^1].

[^1]: [Add persistent directory for VoidSW configuration](https://github.com/flathub/com.eduke32.EDuke32/commit/84c67fafbf84de895086940a033e56c16f4442d6)