### PR TITLE
Use chomping yaml block

### DIFF
--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -38,7 +38,7 @@ modules:
       - install -Dm644 -t ${FLATPAK_DEST}/share/applications/ com.eduke32.EDuke32.desktop
         com.eduke32.EDuke32-mapster32.desktop com.eduke32.EDuke32-voidsw.desktop com.eduke32.EDuke32-wangulator.desktop
       - install -Dm644 -t ${FLATPAK_DEST}/share/appdata/ com.eduke32.EDuke32.appdata.xml
-      - >
+      - |
         SIZES='16 24 32 48 64 128 256'
         GAMES='duke3d sw'
         


### PR DESCRIPTION
This doesn't effect the outcome of the build.

This effects whitespace such that the first lines become:
```
SIZES='16 24 32 48 64 128 256'
GAMES='duke3d sw'

for GAME in ${GAMES} ; do
```
rather than:
```
SIZES='16 24 32 48 64 128 256' GAMES='duke3d sw'
for GAME in ${GAMES} ; do
```
You can see this with `yq '.modules[2]["build-commands"][4]' ./com.eduke32.EDuke32.yml -r`