### PR TITLE
Build with debug symbols

### DIFF
--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -32,7 +32,7 @@ modules:
   - name: EDuke32
     buildsystem: simple
     build-commands:
-      - make duke3d sw kenbuild -j${FLATPAK_BUILDER_N_JOBS} LF=
+      - make duke3d sw kenbuild -j${FLATPAK_BUILDER_N_JOBS} FORCEDEBUG=1 LF=
       - install -Dm755 -t ${FLATPAK_DEST}/bin/ eduke32 mapster32 voidsw wangulator
         ekenbuild ekenbuild-editor
       - install -Dm644 -t ${FLATPAK_DEST}/share/applications/ com.eduke32.EDuke32.desktop


### PR DESCRIPTION
This change means the built binaries will include debug symbols, which get stripped by `flatpak-builder` into `com.eduke32.EDuke32.Debug`.

Before:
```bash
$ flatpak run --devel --command=ls com.eduke32.EDuke32//stable /app/lib/debug/bin
ls: cannot access '/app/lib/debug/bin': No such file or directory
```

After:
```bash
$ flatpak run --devel --command=ls com.eduke32.EDuke32//test /app/lib/debug/bin
eduke32.debug
ekenbuild.debug
ekenbuild-editor.debug
mapster32.debug
voidsw.debug
wangulator.debug
```