### PR TITLE
No xdg-data and update to 20231224-10548-842047589

### DIFF
--- a/com.eduke32.EDuke32.appdata.xml
+++ b/com.eduke32.EDuke32.appdata.xml
@@ -44,6 +44,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="20231224-10548-842047589" date="2023-12-24"/>
     <release version="20231208-10535-2c26af2ed" date="2023-12-09"/>
     <release version="20231206-10534-41c17613f" date="2023-12-06"/>
     <release version="20231204-10530-0bfcf4341" date="2023-12-05"/>

--- a/com.eduke32.EDuke32.desktop
+++ b/com.eduke32.EDuke32.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=EDuke32
 Exec=eduke32
-Icon=com.eduke32.EDuke32-duke3d
+Icon=com.eduke32.EDuke32
 Categories=Game;Shooter
 Keywords=Game;Shooter;Build;Duke32;Duke;Nukem;3D;

--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -14,8 +14,9 @@ finish-args:
   - --filesystem=xdg-documents/VoidSW:create
   # For detecting existing game files
   - --filesystem=~/.var/app/com.valvesoftware.Steam
-  - --filesystem=xdg-data/Steam
   - --filesystem=~/.steam
+  - --filesystem=~/GOG Games
+  - --filesystem=~/.local/share/applications:ro
   # Unfortunately doesn't seem to respect XDG
   - --persist=.config/eduke32
   - --persist=.config/voidsw
@@ -68,12 +69,17 @@ modules:
             install -p -D -m 0644 "${SVG_OUT}" -t "${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/"
           fi
         done
+        
+        for s in ${SIZES} ; do
+          ICON_PREFIX="${FLATPAK_DEST}/share/icons/hicolor/${s}x${s}/apps/${FLATPAK_ID}"
+          cp "${ICON_PREFIX}-duke3d.png" "${ICON_PREFIX}.png"
+        done
     post-install:
       - install -d "${FLATPAK_DEST}/extensions"
     sources:
       - type: archive
-        url: https://dukeworld.com/eduke32/synthesis/20231208-10535-2c26af2ed/eduke32_src_20231208-10535-2c26af2ed.tar.xz
-        sha256: 941a3948e563f70d9bae813307da0bd159c8ce18b787ef7c59d4fcff7be91319
+        url: https://dukeworld.com/eduke32/synthesis/20231224-10548-842047589/eduke32_src_20231224-10548-842047589.tar.xz
+        sha256: 16ed494f9d09920ac4c5f167f8098a2e1f455da32243b7fd63d7d8e1db13b0e2
         x-checker-data:
           type: html
           url: https://dukeworld.com/eduke32/synthesis/latest/


### PR DESCRIPTION
I'm not sure what `--filesystem=xdg-data/Steam` covers that isn't covered by the other options.
Also would there be a downside to read only access to the game data directories?