### PR TITLE
Update EDuke32 to 20241226-10608-8d79c372a

### DIFF
--- a/com.eduke32.EDuke32.appdata.xml
+++ b/com.eduke32.EDuke32.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>com.eduke32.EDuke32</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-only AND LicenseRef-proprietary=https://www.eduke32.com/buildlic.txt</project_license>
   <name>EDuke32</name>
   <summary>EDuke32 is an awesome, free homebrew game engine</summary>
   <description>
@@ -44,8 +44,11 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="20240604-10578-30deaa520" date="2024-06-04">
+    <release version="20241226-10608-8d79c372a" date="2024-12-27">
       <description></description>
+    </release>
+    <release version="20240604-10578-30deaa520" date="2024-06-04">
+      <description/>
     </release>
     <release version="20240523-10572-a3c1d936e" date="2024-05-24">
       <description/>

--- a/com.eduke32.EDuke32.yml
+++ b/com.eduke32.EDuke32.yml
@@ -1,6 +1,6 @@
 app-id: com.eduke32.EDuke32
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: eduke32
 finish-args:
@@ -8,6 +8,7 @@ finish-args:
   - --share=network
   - --socket=x11
   - --socket=pulseaudio
+  - --device=dri
   - --device=all
   # For storing game files
   - --filesystem=xdg-documents/EDuke32:create
@@ -79,13 +80,15 @@ modules:
       - install -d "${FLATPAK_DEST}/extensions"
     sources:
       - type: archive
-        url: https://dukeworld.com/eduke32/synthesis/20240604-10578-30deaa520/eduke32_src_20240604-10578-30deaa520.tar.xz
-        sha256: f9c57817a3540f79426eaa74b19a79dcd75716d4d9cf3e63f5c284ed7660b6a2
+        url: https://dukeworld.com/eduke32/synthesis/20241226-10608-8d79c372a/eduke32_src_20241226-10608-8d79c372a.tar.xz
+        sha256: 6e5f373f660010ad0644c8fdc2eb8f80ced7219ef4bd9a889f8836809d73b97e
         x-checker-data:
           type: html
           url: https://dukeworld.com/eduke32/synthesis/latest/
           version-pattern: eduke32_src_(\d{8}-\d+-[a-g0-9]+).tar.xz
           url-template: https://dukeworld.com/eduke32/synthesis/$version/eduke32_src_$version.tar.xz
+      - type: patch
+        path: gdk_pixbuf_png.diff
       - type: file
         path: com.eduke32.EDuke32.appdata.xml
       - type: file

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,0 @@
-{
-  "disable-external-data-checker": true,
-  "automerge-flathubbot-prs": true
-}

--- a/gdk_pixbuf_png.diff
+++ b/gdk_pixbuf_png.diff
@@ -1,0 +1,23 @@
+diff --git a/GNUmakefile b/GNUmakefile
+index 54618b2e6..53ab71d0d 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -811,6 +811,9 @@ libklzw$(DLLSUFFIX): $(engine_src)/klzw.cpp
+ 	$(COMPILE_STATUS)
+ 	$(RECIPE_IF) $(COMPILER_C) -shared -fPIC $< -o $@ $(RECIPE_RESULT_COMPILE)
+ 
++%.png: %.bmp
++	ffmpeg -i $< -frames:v 1 -update 1 $@
++
+ # to debug the tools link phase, make a copy of this rule explicitly replacing % with the name of a tool, such as kextract
+ %$(EXESUFFIX): $(tools_obj)/%.$o $(foreach i,tools $(tools_deps),$(call expandobjs,$i))
+ 	$(LINK_STATUS)
+@@ -893,7 +896,7 @@ $$($1_obj)/%.$$o: $$($1_rsrc)/%.c | $$($1_obj)
+ 	$$(call MKDIR,$$(dir $$@))
+ 	$$(RECIPE_IF) $$(COMPILER_C) $$($1_cflags) -c $$< -o $$@ $$(RECIPE_RESULT_COMPILE)
+ 
+-$$($1_obj)/%_banner.c: $$($1_rsrc)/%.bmp | $$($1_obj)
++$$($1_obj)/%_banner.c: $$($1_rsrc)/%.png | $$($1_obj)
+ 	echo "#include \"gtkpixdata_shim.h\"" > $$@
+ 	gdk-pixbuf-csource --extern --struct --raw --name=startbanner_pixdata $$^ | sed 's/load_inc//' >> $$@
+ 


### PR DESCRIPTION
* Update platform to 24.08
* Add patch to use ffmpeg to convert bmp to png for gdk-pixbuf-csource
* Add build license link to appstream metadata
* Add dri device in prep for removing all
* Re-enable external data checker

```
make: *** [GNUmakefile:803: wangulator] Error 1
/usr/lib/gcc/x86_64-unknown-linux-gnu/14.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /tmp/ccFHLH03.ltrans23.ltrans.o: in function `startwin_open':
/run/build/EDuke32/source/duke3d/src/startgtk.game.cpp:257:(.text+0x5d0): undefined reference to `startbanner_pixdata'
collect2: error: ld returned 1 exit status
Failed linking eduke32!
```